### PR TITLE
Add opengraph images

### DIFF
--- a/.changeset/quick-owls-check.md
+++ b/.changeset/quick-owls-check.md
@@ -1,0 +1,5 @@
+---
+"@sgcarstrends/web": minor
+---
+
+Add Opengraph Images for cars and COE pages respectively

--- a/app/api/og/coe/route.tsx
+++ b/app/api/og/coe/route.tsx
@@ -1,24 +1,12 @@
 import { ImageResponse } from "next/og";
 import { NextRequest } from "next/server";
-import { loadSearchParams } from "@/app/api/og/search-params";
-import { formatDateToMonthYear } from "@/utils/formatDateToMonthYear";
+import { loadSearchParams } from "@/app/api/og/coe/search-params";
+import { formatCurrency } from "@/utils/format-currency";
+import { formatOrdinal } from "@/utils/formatOrdinal";
 
 export const GET = async (request: NextRequest) => {
-  const {
-    month,
-    title,
-    subtitle,
-    total,
-    topFuelType,
-    topFuelValue,
-    topVehicleType,
-    topVehicleValue,
-  } = loadSearchParams(request);
-
-  let formattedMonth = month;
-  if (month) {
-    formattedMonth = formatDateToMonthYear(month);
-  }
+  const { title, subtitle, biddingNo, categoryA, categoryB, categoryE } =
+    loadSearchParams(request);
 
   return new ImageResponse(
     (
@@ -74,47 +62,71 @@ export const GET = async (request: NextRequest) => {
             >
               <h1 tw="flex flex-col text-left text-3xl font-bold sm:text-4xl">
                 <span>{title}</span>
-                <span tw="text-blue-600">{formattedMonth}</span>
+                <span tw="text-blue-600">
+                  {formatOrdinal(biddingNo)} Bidding Exercise
+                </span>
               </h1>
               <h2 tw="text-gray-600">{subtitle}</h2>
             </div>
-            {total && (
-              <div tw="flex flex-col text-2xl">
-                {total && (
+            {/*TODO: Refactor and clean up*/}
+            <div tw="flex flex-col text-2xl">
+              <div tw="flex flex-col">
+                {categoryA && (
                   <div tw="-mr-64 mb-4 flex w-[50vw] flex-col rounded-2xl bg-gray-50 p-8 shadow-lg">
-                    Total Registrations
+                    Category A
                     <span
                       tw="text-blue-600"
                       style={{ textShadow: `0 2px 4px rgba(0,0,0,0.3)` }}
                     >
-                      {total}
+                      {formatCurrency(categoryA)}
                     </span>
                   </div>
                 )}
-                {topFuelType && (
+                {categoryB && (
                   <div tw="-mr-64 mb-4 flex w-[50vw] flex-col rounded-2xl bg-gray-50 p-8 shadow-lg">
-                    Top Fuel Type
+                    Category B
                     <span
-                      tw="text-green-600"
+                      tw="text-blue-600"
                       style={{ textShadow: `0 2px 4px rgba(0,0,0,0.3)` }}
                     >
-                      {topFuelType}
+                      {formatCurrency(categoryB)}
                     </span>
                   </div>
                 )}
-                {topVehicleType && (
+                {/*<div tw="-mr-64 mb-4 flex w-[50vw] flex-col rounded-2xl bg-gray-50 p-8 shadow-lg">*/}
+                {/*  Category C*/}
+                {/*  <span*/}
+                {/*    tw="text-blue-600"*/}
+                {/*    style={{ textShadow: `0 2px 4px rgba(0,0,0,0.3)` }}*/}
+                {/*  >*/}
+                {/*    {categoryC}*/}
+                {/*  </span>*/}
+                {/*</div>*/}
+                {/*<div tw="-mr-64 mb-4 flex w-[50vw] flex-col rounded-2xl bg-gray-50 p-8 shadow-lg">*/}
+                {/*  Category D*/}
+                {/*  <span*/}
+                {/*    tw="text-blue-600"*/}
+                {/*    style={{ textShadow: `0 2px 4px rgba(0,0,0,0.3)` }}*/}
+                {/*  >*/}
+                {/*    {categoryD}*/}
+                {/*  </span>*/}
+                {/*</div>*/}
+                {categoryE && (
                   <div tw="-mr-64 mb-4 flex w-[50vw] flex-col rounded-2xl bg-gray-50 p-8 shadow-lg">
-                    Top Vehicle Type
+                    Category E
                     <span
-                      tw="text-pink-600"
+                      tw="text-blue-600"
                       style={{ textShadow: `0 2px 4px rgba(0,0,0,0.3)` }}
                     >
-                      {topVehicleType}
+                      {formatCurrency(categoryE)}
                     </span>
                   </div>
                 )}
               </div>
-            )}
+              <span tw="text-xs">
+                * Prices are denoted in Singapore Dollars (SGD)
+              </span>
+            </div>
           </div>
         </div>
       </div>

--- a/app/api/og/coe/search-params.ts
+++ b/app/api/og/coe/search-params.ts
@@ -1,0 +1,14 @@
+import { createLoader, parseAsInteger, parseAsString } from "nuqs/server";
+
+export const ogSearchParams = {
+  title: parseAsString,
+  subtitle: parseAsString,
+  biddingNo: parseAsInteger.withDefault(1),
+  categoryA: parseAsInteger,
+  categoryB: parseAsInteger,
+  categoryC: parseAsInteger,
+  categoryD: parseAsInteger,
+  categoryE: parseAsInteger,
+};
+
+export const loadSearchParams = createLoader(ogSearchParams);

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -21,8 +21,8 @@ export const GET = async (req: NextRequest) => {
           backgroundSize: "100px 100px",
         }}
       >
-        <div tw="flex h-[630px] w-[1200px] flex-col items-center justify-center relative">
-          <div tw="flex items-center gap-x-2 absolute left-8 top-8">
+        <div tw="relative flex h-[630px] w-[1200px] flex-col items-center justify-center">
+          <div tw="absolute top-8 left-8 flex items-center gap-x-2">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               width="24"
@@ -52,11 +52,11 @@ export const GET = async (req: NextRequest) => {
               backgroundImage: "linear-gradient(90deg, #f9fafb, #e5e7eb)",
             }}
           >
-            <div tw="flex flex-col md:flex-row w-full py-12 px-4 md:items-center justify-between p-8">
-              <div tw="flex flex-col text-3xl sm:text-4xl font-bold tracking-tight text-gray-900">
+            <div tw="flex w-full flex-col justify-between p-8 px-4 py-12 md:flex-row md:items-center">
+              <div tw="flex flex-col text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
                 {title || <span>Car Trends ({formattedMonth})</span>}
-                {type && <span tw="capitalize text-blue-600">{type}</span>}
-                {make && <span tw="capitalize text-blue-600">{make}</span>}
+                {type && <span tw="text-blue-600 capitalize">{type}</span>}
+                {make && <span tw="text-blue-600 capitalize">{make}</span>}
               </div>
               {/*<div tw="mt-8 flex md:mt-0">*/}
               {/*  <div tw="flex rounded-md shadow-sm">*/}

--- a/app/api/og/search-params.ts
+++ b/app/api/og/search-params.ts
@@ -1,0 +1,14 @@
+import { createLoader, parseAsInteger, parseAsString } from "nuqs/server";
+
+export const ogSearchParams = {
+  month: parseAsString,
+  title: parseAsString,
+  subtitle: parseAsString,
+  total: parseAsInteger,
+  topFuelType: parseAsString,
+  topFuelValue: parseAsInteger,
+  topVehicleType: parseAsString,
+  topVehicleValue: parseAsInteger,
+};
+
+export const loadSearchParams = createLoader(ogSearchParams);

--- a/app/cars/makes/[make]/page.tsx
+++ b/app/cars/makes/[make]/page.tsx
@@ -41,14 +41,21 @@ export const generateMetadata = async ({
   const formattedMake = deslugify(make).toUpperCase();
   const title = `${formattedMake} Cars Overview: Registration Trends`;
   const description = `${formattedMake} cars overview. Historical car registration trends and monthly breakdown by fuel and vehicle types in Singapore.`;
-  // const images = `/api/og?title=Historical Trend&make=${make}`;
+
+  // TODO: Refactor and clean up
+  const result = await fetchApi<Car[]>(
+    `${API_URL}/makes/${make}?month=${month}`,
+  );
+  const total = result.reduce((total, current) => total + current.number, 0);
+
+  const images = `/api/og?title=${make.toUpperCase()}&subtitle=Stats by Make&month=${month}&total=${total}`;
   const canonical = `/cars/makes/${make}?month=${month}`;
 
   return {
     title,
     description,
     openGraph: {
-      images: `${SITE_URL}/opengraph-image.png`,
+      images,
       url: canonical,
       siteName: SITE_TITLE,
       locale: "en_SG",
@@ -56,7 +63,7 @@ export const generateMetadata = async ({
     },
     twitter: {
       card: "summary_large_image",
-      images: `${SITE_URL}/twitter-image.png`,
+      images,
       site: "@sgcarstrends",
       creator: "@sgcarstrends",
     },

--- a/app/coe/(prices)/columns.tsx
+++ b/app/coe/(prices)/columns.tsx
@@ -2,16 +2,10 @@
 
 import { ArrowUpDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { formatCurrency } from "@/utils/format-currency";
 import { formatOrdinal } from "@/utils/formatOrdinal";
 import type { COEResult } from "@/types";
 import type { ColumnDef } from "@tanstack/react-table";
-
-const formatCurrency = (value: any) =>
-  Intl.NumberFormat("en-SG", {
-    style: "currency",
-    currency: "SGD",
-    minimumFractionDigits: 0,
-  }).format(value);
 
 // const formatPercent = (value: any) =>
 //   Intl.NumberFormat("en-SG", { style: "percent" }).format(value);

--- a/app/coe/(prices)/page.tsx
+++ b/app/coe/(prices)/page.tsx
@@ -34,14 +34,24 @@ const description =
   "Explore historical Certificate of Entitlement (COE) price trends and bidding results for car registrations in Singapore.";
 
 export const generateMetadata = async (): Promise<Metadata> => {
+  // TODO: Refactor and clean up
+  const results = await fetchApi<COEResult[]>(`${API_URL}/coe/latest`);
+  const categories = results.reduce<Record<string, number>>(
+    (category, current) => {
+      category[current.vehicle_class] = current.premium;
+      return category;
+    },
+    {},
+  );
+
   const canonical = "/coe";
-  // const images = "/api/og?title=COE Result";
+  const images = `/api/og/coe?title=COE Results&subtitle=Overview&biddingNo=2&categoryA=${categories["Category A"]}&categoryB=${categories["Category B"]}&categoryC=${categories["Category C"]}&categoryD=${categories["Category D"]}&categoryE=${categories["Category E"]}`;
 
   return {
     title,
     description,
     openGraph: {
-      images: `${SITE_URL}/opengraph-image.png`,
+      images,
       url: canonical,
       siteName: SITE_TITLE,
       locale: "en_SG",
@@ -49,7 +59,7 @@ export const generateMetadata = async (): Promise<Metadata> => {
     },
     twitter: {
       card: "summary_large_image",
-      images: `${SITE_URL}/twitter-image.png`,
+      images,
       site: "@sgcarstrends",
       creator: "@sgcarstrends",
     },

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   plugins: ["prettier-plugin-tailwindcss"],
+  tailwindAttributes: ["tw"],
 };

--- a/types/index.ts
+++ b/types/index.ts
@@ -89,3 +89,26 @@ export interface LinkItem {
   icon?: LucideIcon;
   comingSoon?: boolean;
 }
+
+export interface Registration {
+  data: {
+    month: string;
+    fuelType: {
+      Diesel: number;
+      "Petrol-Electric (Plug-In)": number;
+      Petrol: number;
+      Electric: number;
+      "Petrol-Electric": number;
+    };
+    vehicleType: {
+      Hatchback: number;
+      "Coupe/Convertible": number;
+      Sedan: number;
+      "Multi-purpose Vehicle": number;
+      "Station-wagon": number;
+      "Multi-purpose Vehicle/Station-wagon": number;
+      "Sports Utility Vehicle": number;
+    };
+    total: number;
+  };
+}

--- a/utils/__tests__/format-currency.test.ts
+++ b/utils/__tests__/format-currency.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { formatCurrency } from "@/utils/format-currency";
+
+describe("formatCurrency", () => {
+  it("should format whole numbers correctly", () => {
+    expect(formatCurrency(1000)).toBe("$1,000");
+    expect(formatCurrency(50000)).toBe("$50,000");
+    expect(formatCurrency(100000)).toBe("$100,000");
+  });
+
+  it("should format decimal numbers without fraction digits", () => {
+    expect(formatCurrency(1000.5)).toBe("$1,001");
+    expect(formatCurrency(999.99)).toBe("$1,000");
+    expect(formatCurrency(1000.1)).toBe("$1,000");
+  });
+
+  it("should handle zero value", () => {
+    expect(formatCurrency(0)).toBe("$0");
+  });
+
+  it("should handle negative values", () => {
+    expect(formatCurrency(-1000)).toBe("-$1,000");
+    expect(formatCurrency(-50000)).toBe("-$50,000");
+  });
+
+  it("should handle large numbers", () => {
+    expect(formatCurrency(1000000)).toBe("$1,000,000");
+    expect(formatCurrency(1234567)).toBe("$1,234,567");
+  });
+
+  it("should handle small numbers", () => {
+    expect(formatCurrency(1)).toBe("$1");
+    expect(formatCurrency(99)).toBe("$99");
+  });
+});

--- a/utils/format-currency.ts
+++ b/utils/format-currency.ts
@@ -1,0 +1,7 @@
+export const formatCurrency = (value: number) =>
+  Intl.NumberFormat("en-SG", {
+    style: "currency",
+    currency: "SGD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);


### PR DESCRIPTION
- **Configure Prettier Tailwind CSS plugin to format tw attributes correctly**
- **Add opengraph image for core pages**
- **Add changelog**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dynamic Open Graph and Twitter images are now generated for the cars and COE pages, reflecting real-time data such as registration totals, top vehicle and fuel types, and COE premium prices.
  - Enhanced Open Graph image layouts with improved branding, styling, and richer information.
- **Bug Fixes**
  - Currency formatting is now consistent across the app using a unified utility.
- **Chores**
  - Added configuration for Tailwind CSS attribute support in Prettier.
- **Tests**
  - Introduced tests for the currency formatting utility to ensure correct output.
- **Documentation**
  - Added a changeset documenting the minor version update and new Open Graph image features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->